### PR TITLE
Creation of two inline validation patterns

### DIFF
--- a/_prototypes/validation/index.html
+++ b/_prototypes/validation/index.html
@@ -163,7 +163,7 @@ $( document ).ready(function() {
 
   function validate(){
     var str = $('#q3r1').val();
-      if(str.search(/\D/i)>=0){
+      if(str.search(/\D/i)>=0){ // Check for any non digit
         doError();
       } else {
         removeError();

--- a/_prototypes/validation/index.html
+++ b/_prototypes/validation/index.html
@@ -208,7 +208,7 @@ $( document ).ready(function() {
     $('#q3r1').val(q3r1_answer);
   }
 
-  console.info(sessionStorage);
+  //console.info(sessionStorage);
 
   $('.qa-btn-submit').click(function(e) {
     e.preventDefault();

--- a/_prototypes/validation/index.html
+++ b/_prototypes/validation/index.html
@@ -1,0 +1,246 @@
+---
+title: Validation patterns
+project: Validation
+globalcss: false
+
+---
+
+<header class="page__header">
+{% include survey-header.html %}
+{% include bar.html %}
+</header>
+<style>
+.has-error {
+  color: #D0121E;
+  font-weight: 700;
+}
+.input--has-error {
+  background-color: #fff;
+  border-color: #d0121e;
+  box-shadow: 0 0 0 1px #d0121e;
+  font-weight: 700;
+  color: #d0121e;
+}
+.input--has-error:focus,
+.input--has-error:hover {
+  border-color: #d0121e;
+  outline-color: #d0121e;
+  box-shadow: 0 0 0 1px #d0121e;
+}
+.input--has-error-old {
+  background-color: #fbecec;
+  transition: background-color 1s ease-in-out;
+}
+</style>
+<div class="page__subheader">
+  <div class="container">
+    <a class="mars" href="../index">Previous</a>
+  </div>
+</div>
+
+<div class="page__container container">
+  <div class="grid grid--reverse">
+    <div class="grid__col col-4@m">
+    </div>
+    <div class="grid__col col-7@m pull-1@m">
+      <main role="main" id="main" class="page__main">
+        <form action="../thankyou" class="form qa-questionnaire-form" role="form" autocomplete="off" novalidate="">
+          <div class="group" id="rsi">
+            <div class="block" id="total-retail-turnover">
+              <section class="section" id="total-retail-turnover-section">
+                <h2 class="section__title neptune">Inline validation pattern</h2>
+                <div class="section__description mars">
+                  <p>July 2017</p>
+                  <p>To trigger an error enter a value including pence</p>
+                </div>
+                <div class="question" id="total-retail-turnover-question">
+                  <h1 class="question__title saturn">
+                    What was the value of the business&rsquo;s total sales of <span class="highlight">food</span>?
+                  </h1>
+                  <div class="question__answers">
+                    <div class="question__answer">
+                      <div class="answer answer--currency" id="total-retail-turnover-answer">
+                        <div class="answer__fields js-fields">
+                          <div class="field">
+                            <label for="q3r1" id="label-total-retail-turnover-answer" class="label venus ">
+                              <div class="label__inner">
+                                Total value of food sales
+                              </div>
+                              <div class="question__description mars" id="q3r1_description">Round to the nearest pound. Do not include pence.</div>
+                            </label>
+                            <div class="input-type input-type--currency">
+                              <span class="input-type__type" id="q3r1type">£</span>
+                              <input id="q3r1" value="" data-qa="input-text" name="q3r1" class="input input--text input-type__input">
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="guidance js-details" data-show-label="Show further guidance" data-hide-label="Hide further guidance">
+                        <a class="guidance__link js-details-trigger js-details-label mars" href="#guidance-permanent-or-family-home-answer" aria-expanded="false" data-guidance-trigger="true" aria-controls="guidance-permanent-or-family-home-answer-body" id="guidance-permanent-or-family-home-answer-trigger" data-ga-category="Help" data-ga-label="permanent-or-family-home-answer" data-ga="click" data-ga-action="Guidance click">Show further guidance</a>
+                          <div class="guidance__main js-details-body" id="guidance-permanent-or-family-home-answer-body" aria-hidden="true">
+                            <div class="guidance__content mars">
+                            <h3 class="venus">Include</h3>
+                            <ul class="mars">
+                              <li>all fresh food</li>
+                              <li>other food for human consumption (except chocolate and sugar confectionery)</li>
+                              <li>soft drinks</li>
+                            </ul>
+                            <h3 class="venus">Exclude</h3>
+                            <ul class="mars">
+                              <li>sales from catering facilities used by customers</li>
+                              <li>National lottery</li>
+                            </ul>
+                          </div>
+                        </div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+            </div>
+            <div class="question" id="total-retail-turnover-question" style="margin-top:1.5rem;">
+              <h1 class="question__title saturn">
+                What was the value of the business&rsquo;s total sales of <span class="highlight">alcohol</span>?
+              </h1>
+              <div class="question__answers">
+                <div class="question__answer">
+                  <div class="answer answer--currency" id="total-retail-turnover-answer">
+                    <div class="answer__fields js-fields">
+                      <div class="field">
+                        <label for="q3r2" id="label-total-retail-turnover-answer" class="label venus ">
+                          <div class="label__inner">
+                            Total value of alcohol sales
+                          </div>
+                          <div class="question__description mars" id="q3r1_description">Round to the nearest pound. Do not include pence.</div>
+                        </label>
+                        <div class="input-type input-type--currency">
+                          <span class="input-type__type" id="q3r2type">£</span>
+                          <input id="q3r2" value="" data-qa="input-text" name="q3r2" class="input input--text input-type__input">
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="guidance js-details" data-show-label="Show further guidance" data-hide-label="Hide further guidance">
+                    <a class="guidance__link js-details-trigger js-details-label mars" href="#guidance-permanent-or-family-home-answer" aria-expanded="false" data-guidance-trigger="true" aria-controls="guidance-permanent-or-family-home-answer-body" id="guidance-permanent-or-family-home-answer-trigger" data-ga-category="Help" data-ga-label="permanent-or-family-home-answer" data-ga="click" data-ga-action="Guidance click">Show further guidance</a>
+                      <div class="guidance__main js-details-body" id="guidance-permanent-or-family-home-answer-body" aria-hidden="true">
+                        <div class="guidance__content mars">
+                        <h3 class="venus">Include</h3>
+                        <ul class="mars">
+                          <li>all fresh food</li>
+                          <li>other food for human consumption (except chocolate and sugar confectionery)</li>
+                          <li>soft drinks</li>
+                        </ul>
+                        <h3 class="venus">Exclude</h3>
+                        <ul class="mars">
+                          <li>sales from catering facilities used by customers</li>
+                          <li>National lottery</li>
+                        </ul>
+                      </div>
+                    </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+          </div>
+          <button class="btn btn--primary btn--lg qa-btn-submit venus" type="submit" name="">Save and continue</button>
+          <div class="u-mb-m">
+            <button class="btn btn--link mars js-btn-save" type="submit" name="action[save_sign_out]">Save and complete later</button>
+          </div>
+        </form>
+        <a class="page__previous page__previous--bottom js-previous-link" href="../index" id="bottom-previous">Previous</a>
+      </main>
+    </div>
+  </div>
+</div>
+<script>
+$( document ).ready(function() {
+  $('#q3r1').keyup(function(){
+    validate();
+  });
+  $('#q3r2').keyup(function(){
+    validate2()
+  });
+
+  function validate(){
+    var str = $('#q3r1').val();
+      if(str.indexOf('.')>= 0){
+        doError();
+      } else {
+        removeError();
+      }
+  }
+  function doError(){
+    var elem = $('#q3r1');
+    var className = "input--has-error";
+    if(!elem.hasClass(className)){
+        $('#q3r1_description').prepend('Error:&nbsp;').addClass('has-error');
+      }
+    $('#q3r1').addClass('input--has-error');
+  }
+
+  function removeError(){
+    $('#q3r1').removeClass('input--has-error');
+    $('#q3r1_description').removeClass('has-error').html('Round to the nearest pound. Do not include pence.');
+  }
+
+  function validate2(){
+    var str = $('#q3r2').val();
+    if(str.indexOf('.')>= 0){
+      $('#q3r2').addClass('input--has-error-old');
+    } else {
+      $('#q3r2').removeClass('input--has-error-old');
+    }
+  }
+
+
+  if ($('.q1').length > 0) {
+    var q1var = sessionStorage.getItem('q1r1');
+    $('.q1').text(q1var);
+  }
+  if ($('.config1').length>0){
+    var config1 = sessionStorage.getItem('config1');
+    $('.config1').html(config1);
+  }
+
+  var q3r1_answer = sessionStorage.getItem('q3r1');
+
+  if(q3r1_answer!==""){
+    $('#q3r1').val(q3r1_answer);
+  }
+
+  console.info(sessionStorage);
+
+  $('.qa-btn-submit').click(function(e) {
+    e.preventDefault();
+
+    var editing = sessionStorage.getItem('editing');
+    if(editing=='true'){
+      window.location.href="../playback/";
+    } else {
+      window.location.href = "../section-2/"; // target of save and continue
+    }
+
+        if ("text" === "text") {
+          var inputValue = $("input[name='q3r1']").val();
+          sessionStorage.setItem('q3r1', inputValue);
+
+        } else {
+          var inputValue = $("input[name='q3r1']:checked").val();
+          sessionStorage.setItem('q3r1', inputValue);
+        }
+  });
+
+  $('.js-details-trigger').click(function(e) {
+    var text = $(this).text();
+    if ($('.js-details').hasClass('is-expanded')){
+      $(this).text(text.replace('Hide', 'Show'));
+    } else {
+      $(this).text(text.replace('Show', 'Hide'));
+    }
+    e.preventDefault();
+    $('.js-details').toggleClass('is-expanded');
+
+  });
+
+});
+</script>

--- a/_prototypes/validation/index.html
+++ b/_prototypes/validation/index.html
@@ -163,7 +163,7 @@ $( document ).ready(function() {
 
   function validate(){
     var str = $('#q3r1').val();
-      if(str.indexOf('.')>= 0){
+      if(str.search(/\D/i)>=0){
         doError();
       } else {
         removeError();


### PR DESCRIPTION
### What is the context of this PR?

To create a test for two differing patterns of inline validation for a numeric input.

1. On encountering an error it prepends "Error: " to the input description, changes the `border` and `box-shadow` colour to `$color-errors` and the `font-weight` of the input and input description to `700`
![ons-eq-inline-error-01](https://user-images.githubusercontent.com/22910336/28213367-a89fe4c0-689d-11e7-9155-fd9bfc7a4ddb.png)

2. On encountering an error it transitions the background colour to `$color-light-red`. This is currently in use on the "total-breakdown" pattern.
![ons-eq-inline-error-02](https://user-images.githubusercontent.com/22910336/28213411-e05e12ba-689d-11e7-9f9a-a86c76df2c11.png)

### How to review
Enter a value which includes a decimal place and check that listed changes have occurred.
